### PR TITLE
RFC 1214 fix

### DIFF
--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -5,7 +5,7 @@ use point::Point;
 
 
 /// Types representable as an Envelope.
-pub trait Envelope<'a, P>: Sized {
+pub trait Envelope<'a, P: 'a>: Sized {
     /// An iterator yielding references to `P`s.
     type Points: Iterator<Item=&'a P> + ExactSizeIterator + DoubleEndedIterator + Clone + 'a;
 


### PR DESCRIPTION
This library will eventually break with Rust 1.5. The change to fix it
is very small.

You might want to release a version on crates.io with this as well.